### PR TITLE
feat: add database container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME=Bet
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
@@ -22,11 +22,13 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=pgsql
-DB_HOST=127.0.0.1
+# DB_HOST with container name for Bridge network connection 
+# @see https://docs.docker.com/engine/network/
+DB_HOST=database 
 DB_PORT=5432
-DB_DATABASE=bet
-DB_USERNAME=root
-DB_PASSWORD=
+DB_DATABASE=bet_db
+DB_USERNAME=postgres
+DB_PASSWORD=pswd
 
 SESSION_DRIVER=database
 SESSION_LIFETIME=120

--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,7 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=pgsql
-# DB_HOST with container name for Bridge network connection 
-# @see https://docs.docker.com/engine/network/
-DB_HOST=database 
+DB_HOST=127.0.0.1
 DB_PORT=5432
 DB_DATABASE=bet_db
 DB_USERNAME=postgres

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 /.idea
 /.vscode
 /.zed
+/dbdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,4 @@
 services:
-    laravel:
-        container_name: laravel
-        build: docker/laravel
-        command: php artisan serve --host=0.0.0.0
-        volumes:
-            - .:/app
-        ports:
-            - 8000:8000
-        depends_on:
-            database:
-                condition: service_started
-    vite:
-        container_name: vite
-        build: docker/vite
-        command: npm run dev.host
-        volumes:
-            - .:/app
-        ports:
-            - 5173:5173
     database:
         image: postgres
         container_name: database
@@ -28,4 +9,4 @@ services:
         ports:
             - 5432:5432
         volumes:
-            - ./docker/db:/var/lib/postgresql/data
+            - /dbdata:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+    laravel:
+        container_name: laravel
+        build: docker/laravel
+        command: php artisan serve --host=0.0.0.0
+        volumes:
+            - .:/app
+        ports:
+            - 8000:8000
+        depends_on:
+            database:
+                condition: service_started
+    vite:
+        container_name: vite
+        build: docker/vite
+        command: npm run dev.host
+        volumes:
+            - .:/app
+        ports:
+            - 5173:5173
+    database:
+        image: postgres
+        container_name: database
+        environment:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: pswd
+            POSTGRES_DB: bet_db
+        ports:
+            - 5432:5432
+        volumes:
+            - ./docker/db:/var/lib/postgresql/data

--- a/docker/laravel/Dockerfile
+++ b/docker/laravel/Dockerfile
@@ -1,0 +1,14 @@
+FROM php
+
+RUN apt update && \
+    apt upgrade && \
+    apt install -y nano
+    
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN php artisan key:generate && \
+    php artisan migrate && \
+    php artisan seed
+
+WORKDIR /app

--- a/docker/vite/Dockerfile
+++ b/docker/vite/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian
+
+RUN apt update && apt upgrade && apt install -y bash curl apt-utils nano
+
+# Install NodeJS with NPM
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt install -y nodejs
+
+WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "bet",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "app",
+    "name": "bet-test",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "dev.host": "npm run dev -- --host=0.0.0.0"
     },
     "devDependencies": {
         "@inertiajs/vue3": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "build": "vite build",
         "dev": "vite",
-        "dev.host": "npm run dev -- --host=0.0.0.0"
+        "init": "bash ./scripts/init.sh"
     },
     "devDependencies": {
         "@inertiajs/vue3": "^1.0.0",

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+npm i; composer i
+
+# Check if .env file does not exist
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo $'\n.env file created from .env.example.'
+else
+  echo $'\n.env file already exists. No action taken.'
+fi
+
+# Check if APP_KEY in .env is empty or unset
+if ! grep -q "^APP_KEY=" .env || [ -z "$(grep "^APP_KEY=" .env | cut -d '=' -f2)" ]; then
+  php artisan key:generate
+else
+  echo $'\nAPP_KEY already exists and is not empty. No action taken.'
+fi
+
+# Check if port 5432 is open on localhost
+if (echo > /dev/tcp/localhost/5432) &>/dev/null; then
+  php artisan migrate && php artisan db:seed
+  echo $'\nMigration and seeding completed.'
+else
+  echo $'\nNo database detected on port 5432. Migration and seeding skipped.'
+fi


### PR DESCRIPTION
this PR adds a database container inside `docker-compose.yml` file, that can be executed using `docker compose up -d`.

also, it adds a `init` npm script to initialize newly cloned repositories, copying `.env` file, setting constants, and also migrating and seeding the database.